### PR TITLE
Add XML printing

### DIFF
--- a/astpath/cli.py
+++ b/astpath/cli.py
@@ -16,9 +16,9 @@ from astpath.search import search
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-s', '--hide-lines', help="hide source lines, showing only line numbers", action='store_true',)
 parser.add_argument('-q', '--quiet', help="hide output of matches", action='store_true',)
 parser.add_argument('-v', '--verbose', help="increase output verbosity", action='store_true',)
+parser.add_argument('-x', '--xml', help="print only the matching XML elements", action='store_true',)
 parser.add_argument('-a', '--abspaths', help="show absolute paths", action='store_true',)
 parser.add_argument('-R', '--no-recurse', help="ignore subdirectories, searching only files in the specified directory", action='store_true',)
 parser.add_argument('-d', '--dir', help="search directory or file", default='.',)
@@ -41,14 +41,14 @@ def main():
 
     before_context = args.before_context or args.context
     after_context = args.after_context or args.context
-    if (before_context or after_context) and args.hide_lines:
+    if (before_context or after_context) and args.quiet:
         print("ERROR: Context cannot be specified when suppressing output.")
         exit(1)
 
     search(
         args.dir,
         ' '.join(args.expr),
-        show_lines=not args.hide_lines,
+        print_xml=args.xml,
         print_matches=not args.quiet,
         verbose=args.verbose,
         abspaths=args.abspaths,

--- a/astpath/search.py
+++ b/astpath/search.py
@@ -158,7 +158,6 @@ def search(
                 tostring = _tostring_factory()
                 for element in matching_elements:
                     print(tostring(xml_ast, pretty_print=True))
-                    # print(unicode(tostring(xml_ast, pretty_print=True), 'utf-8'))
 
             matching_lines = linenos_from_xml(matching_elements, query=query, node_mappings=node_mappings)
             global_matches.extend(zip(repeat(filename), matching_lines))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name='astpath',
     packages=['astpath'],
-    version='0.7.0',
+    version='0.8.0',
     description='A query language for Python abstract syntax trees',
     license='MIT',
     author='H. Chase Stevens',


### PR DESCRIPTION
* remove `return_lines` kwarg from `find_in_ast` added in #2
* quiet option to not print matches (useful with xml option)
* add the --xml to print xml of matched objects. good for debugging expr