### PR TITLE
Added optional support of regex in XPath

### DIFF
--- a/astpath/cli.py
+++ b/astpath/cli.py
@@ -21,6 +21,7 @@ parser.add_argument('-v', '--verbose', help="increase output verbosity", action=
 parser.add_argument('-x', '--xml', help="print only the matching XML elements", action='store_true',)
 parser.add_argument('-a', '--abspaths', help="show absolute paths", action='store_true',)
 parser.add_argument('-R', '--no-recurse', help="ignore subdirectories, searching only files in the specified directory", action='store_true',)
+parser.add_argument('-re', '--regular-expressions', help="support regular expressions in XPath", action='store_true',)
 parser.add_argument('-d', '--dir', help="search directory or file", default='.',)
 parser.add_argument('-A', '--after-context', help="lines of context to display after matching line", type=int, default=0,)
 parser.add_argument('-B', '--before-context', help="lines of context to display after matching line", type=int, default=0,)
@@ -55,6 +56,7 @@ def main():
         recurse=recurse,
         before_context=before_context,
         after_context=after_context,
+        allow_re=args.regular_expressions
     )
 
 

--- a/astpath/cli.py
+++ b/astpath/cli.py
@@ -21,7 +21,7 @@ parser.add_argument('-v', '--verbose', help="increase output verbosity", action=
 parser.add_argument('-x', '--xml', help="print only the matching XML elements", action='store_true',)
 parser.add_argument('-a', '--abspaths', help="show absolute paths", action='store_true',)
 parser.add_argument('-R', '--no-recurse', help="ignore subdirectories, searching only files in the specified directory", action='store_true',)
-parser.add_argument('-re', '--regular-expressions', help="support regular expressions in XPath", action='store_true',)
+parser.add_argument('-re', '--regular-expressions', help="support namespace with regular expressions in XPath", action='store_true',)
 parser.add_argument('-d', '--dir', help="search directory or file", default='.',)
 parser.add_argument('-A', '--after-context', help="lines of context to display after matching line", type=int, default=0,)
 parser.add_argument('-B', '--before-context', help="lines of context to display after matching line", type=int, default=0,)
@@ -56,7 +56,7 @@ def main():
         recurse=recurse,
         before_context=before_context,
         after_context=after_context,
-        allow_re=args.regular_expressions
+        allow_ns=args.regular_expressions
     )
 
 

--- a/astpath/search.py
+++ b/astpath/search.py
@@ -21,13 +21,13 @@ except ImportError:
     from xml.etree.ElementTree import tostring
     XML_VERSION = XMLVersions.XML
 
-
+ns = {"re": "http://exslt.org/regular-expressions"}
 PYTHON_EXTENSION = '{}py'.format(os.path.extsep)
 
 
-def _query_factory(verbose=False):
+def _query_factory(verbose=False, allow_re=False):
     def lxml_query(element, expression):
-        return element.xpath(expression)
+        return element.xpath(expression, namespaces=ns)
 
     def xml_query(element, expression):
         return element.findall(expression)
@@ -106,7 +106,8 @@ def file_to_xml_ast(filename, omit_docstrings=False, node_mappings=None):
 def search(
         directory, expression, print_matches=False, print_xml=False,
         verbose=False, abspaths=False, recurse=True,
-        before_context=0, after_context=0, extension=PYTHON_EXTENSION
+        before_context=0, after_context=0, extension=PYTHON_EXTENSION,
+        allow_re=False
 ):
     """
     Perform a recursive search through Python files.
@@ -114,7 +115,7 @@ def search(
     Only for files in the given directory for items matching the specified
     expression.
     """
-    query = _query_factory(verbose=verbose)
+    query = _query_factory(verbose=verbose, allow_re=allow_re)
 
     if os.path.isfile(directory):
         if recurse:

--- a/astpath/search.py
+++ b/astpath/search.py
@@ -25,9 +25,10 @@ ns = {"re": "http://exslt.org/regular-expressions"}
 PYTHON_EXTENSION = '{}py'.format(os.path.extsep)
 
 
-def _query_factory(verbose=False, allow_re=False):
+def _query_factory(verbose=False, allow_ns=True):
+    namespaces = ns if allow_ns else {}
     def lxml_query(element, expression):
-        return element.xpath(expression, namespaces=ns)
+        return element.xpath(expression, namespaces=namespaces)
 
     def xml_query(element, expression):
         return element.findall(expression)
@@ -107,7 +108,7 @@ def search(
         directory, expression, print_matches=False, print_xml=False,
         verbose=False, abspaths=False, recurse=True,
         before_context=0, after_context=0, extension=PYTHON_EXTENSION,
-        allow_re=False
+        allow_ns=True
 ):
     """
     Perform a recursive search through Python files.
@@ -115,7 +116,7 @@ def search(
     Only for files in the given directory for items matching the specified
     expression.
     """
-    query = _query_factory(verbose=verbose, allow_re=allow_re)
+    query = _query_factory(verbose=verbose, allow_ns=allow_ns)
 
     if os.path.isfile(directory):
         if recurse:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name='astpath',
     packages=['astpath'],
-    version='0.8.0',
+    version='0.9.0',
     description='A query language for Python abstract syntax trees',
     license='MIT',
     author='H. Chase Stevens',


### PR DESCRIPTION
I as a developer would like to specify regex in XPath queries for more precise search.
Example: `//targets/Name[not(re:match(@id,'pipeline$'))`