### PR TITLE
Re-establish ability to tell numbers from strings etc

### DIFF
--- a/astpath/asts.py
+++ b/astpath/asts.py
@@ -80,6 +80,13 @@ def convert_to_xml(node, omit_docstrings=False, node_mappings=None):
                     )
 
         elif field_value is not None:
+            ## add type attribute e.g. so we can distinguish strings from numbers etc
+            ## in older Python (< 3.8) type could be identified by Str vs Num and s vs n etc
+            ## e.g. <Constant lineno="1" col_offset="6" type="int" value="1"/>
+            _set_encoded_literal(
+                partial(xml_node.set, 'type'),
+                type(field_value).__name__
+            )
             _set_encoded_literal(
                 partial(xml_node.set, field_name),
                 field_value

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name='astpath',
     packages=['astpath'],
-    version='0.9.0',
+    version='0.9.1',
     description='A query language for Python abstract syntax trees',
     license='MIT',
     author='H. Chase Stevens',


### PR DESCRIPTION
Thanks for astpath - your library has been very useful for working with the AST. Unfortunately, Python 3.8 has added some major difficulties. Crucial differences which are distinguishable in the AST itself have become lost in the XML version of the AST. If I want to know if "1" is a number or a string it is no longer possible. The proposed patch solves that problem with one small change. Examples:

From AST in Python < 3.8 (without patch)
===============================
    <Num lineno="1" col_offset="20" n="1"/>  ## number
    <Str lineno="1" col_offset="20" s="1"/>  ## string

From AST in Python < 3.8 (patched)
===============================
No harm done - just additional ability to identify details of what is in the AST

    <Num lineno="1" col_offset="20" type="int" n="1"/>  ## number, specifically an integer
    <Str lineno="1" col_offset="20" type="str" s="1"/>  ## string

From AST Python 3.8+ (without patch)
=============================
    <Constant lineno="1" col_offset="20" value="1"/>  ## ambiguous - number or string?

From AST Python 3.8+ (patched)
=========================
Ability to disambiguate, for example, numbers and strings

    <Constant lineno="1" col_offset="20" type="int" value="1"/>  ## integer
    <Constant lineno="1" col_offset="20" type="str" value="1"/>  ## string