### PR TITLE
Pass filename to ast.parse

### DIFF
--- a/astpath/search.py
+++ b/astpath/search.py
@@ -103,9 +103,9 @@ def linenos_from_xml(elements, query=_query_factory(), node_mappings=None):
     return lines
 
 
-def file_contents_to_xml_ast(contents, omit_docstrings=False, node_mappings=None):
+def file_contents_to_xml_ast(contents, omit_docstrings=False, node_mappings=None, filename='<unknown>'):
     """Convert Python file contents (as a string) to an XML AST, for use with find_in_ast."""
-    parsed_ast = ast.parse(contents)
+    parsed_ast = ast.parse(contents, filename)
     return convert_to_xml(
         parsed_ast,
         omit_docstrings=omit_docstrings,
@@ -121,6 +121,7 @@ def file_to_xml_ast(filename, omit_docstrings=False, node_mappings=None):
         contents,
         omit_docstrings=omit_docstrings,
         node_mappings=node_mappings,
+        filename=filename,
     )
 
 


### PR DESCRIPTION
We are using the bellybutton to implement some custom linting rules, however when someone would have a python file with syntax errors it is difficult to see which file caused the error. In this PR I make it possible to pass the filename to ast.parse so that if parsing fails because of syntax errors we know which file it was that caused it.