### PR TITLE
Print regular UTF-8 string instead of bytes-string

### DIFF
--- a/astpath/search.py
+++ b/astpath/search.py
@@ -179,7 +179,7 @@ def search(
             if print_xml:
                 tostring = _tostring_factory()
                 for element in matching_elements:
-                    print(tostring(xml_ast, pretty_print=True))
+                    print(tostring(xml_ast, pretty_print=True, encoding='unicode'))
 
             matching_lines = linenos_from_xml(matching_elements, query=query, node_mappings=node_mappings)
             global_matches.extend(zip(repeat(filename), matching_lines))


### PR DESCRIPTION
Printing a bytes string looks unreadable in the terminal
e.g.
```
b'<tag1>\n    <tag2/>\n</tag1>'
```
What we want is more like:
```
<tag1>
    <tag2/>
</tag1>
```
Specify encoding to do this

Works for both xml and lxml
https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring
https://lxml.de/3.6/api/lxml.etree-module.html#tostring